### PR TITLE
Fix: Return 409 Conflict for existing email during subscription

### DIFF
--- a/src/main/java/com/foodrecall/controller/UserSubscriptionController.java
+++ b/src/main/java/com/foodrecall/controller/UserSubscriptionController.java
@@ -36,7 +36,10 @@ public class UserSubscriptionController {
         subscription.setState(request.getState());
 
         String response = userSubscriptionService.subscribeUser(subscription);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        if (response.equals("409"))
+            return new ResponseEntity<>("Email already subscribed!", HttpStatus.CONFLICT);
+        else
+            return new ResponseEntity<>(subscription.getEmail() + " subscribed successfully!", HttpStatus.CREATED);
     }
 
     @GetMapping

--- a/src/main/java/com/foodrecall/service/impl/UserSubscriptionServiceImpl.java
+++ b/src/main/java/com/foodrecall/service/impl/UserSubscriptionServiceImpl.java
@@ -42,12 +42,12 @@ public class UserSubscriptionServiceImpl implements UserSubscriptionService {
     @Override
     public String subscribeUser(UserSubscription subscription) {
         if (isAlreadySubscribed(subscription.getEmail(), subscription.getState())) {
-            return "Already subscribed!";
+            return "409"; // Conflict - Email already subscribed.
         }
 
         try {
             saveSubscription(subscription);
-            return subscription.getEmail() + " Successfully subscribed.";
+            return "201"; // Created - Subscription successful.
         } catch (Exception e) {
             System.err.println("Error while saving subscription: " + e.getMessage());
             return "Subscription failed due to an internal error.";


### PR DESCRIPTION
Manage the appropriate status code in case the email is already subscribed. 